### PR TITLE
Fixes!

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 Changelog for WWW::Mechanize::TreeBuilder
 
+  - Fix for global destruction where $self->tree has already been deleted
+  - Fix for composing onto classes which already have a DEMOLISH method
+    by providing a method modifier, rather than the DEMOLISH sub itself.
+  - Fix being composed onto non-Moose classes by wrapping the DESTORY
+    method rather than the DEMOLISH method.
+
 1.10003 - 2010 Sep 23
   - Fix for rt: 57723: Tests failing on Test-Simple 0.96 ( Kent Fredric )
 

--- a/lib/WWW/Mechanize/TreeBuilder.pm
+++ b/lib/WWW/Mechanize/TreeBuilder.pm
@@ -184,10 +184,12 @@ around '_make_request' => sub {
   return $ret;
 };
 
-sub DEMOLISH {
+sub DESTROY {}
+
+after DESTROY => sub {
   my $self = shift;
-  $self->tree->delete if $self->has_tree;
-}
+  $self->tree->delete if ($self->has_tree && $self->tree);
+};
 
 };
 


### PR DESCRIPTION
Hiya

This fixes a global destruction issue I'm seeing inside Gitalist, and also fixes destruction when composed onto a normal WWW::Mech class that doesn't use Moose::Object (and ergo doesn't get DEMOLISH called)
