### PR TITLE
remove use of Class::MOP::load_class

### DIFF
--- a/lib/WWW/Mechanize/TreeBuilder.pm
+++ b/lib/WWW/Mechanize/TreeBuilder.pm
@@ -82,11 +82,12 @@ element_class when C<tree_class> is "HTML::TreeBuilder" or
 
 use MooseX::Role::Parameterized;
 use Moose::Util::TypeConstraints;
+use Class::Load 'load_class';
 #use HTML::TreeBuilder;
 
 subtype 'WWW.Mechanize.TreeBuilder.LoadClass'
   => as 'Str'
-  => where { Class::MOP::load_class($_) }
+  => where { load_class($_) }
   => message { "Cannot load class $_" };
 
 subtype 'WWW.Mechanize.TreeBuilder.TreeClass'

--- a/t/lib/MockTreeBuilder.pm
+++ b/t/lib/MockTreeBuilder.pm
@@ -13,7 +13,7 @@ $WWW::Mechanize::TreeBuilder::ELEMENT_CLASS_MAPPING{"@{[__PACKAGE__]}"} = 'MockT
 
 package #
   MockTreeBuilderEle;
-
+$INC{'MockTreeBuilderEle.pm'}=1; # help stricter Moose checking
 use base 'HTML::Element';
 
 sub some_other_method { "I exist in " . Scalar::Util::blessed($_[0]) };


### PR DESCRIPTION
also, make Moose's new "is a class loaded?" test happy
